### PR TITLE
Support for Python 2.7

### DIFF
--- a/meraki_api/__version__.py
+++ b/meraki_api/__version__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Meraki Dashboard API
 ~~~~~~~~~~~~~~~~~~~~

--- a/meraki_api/devices.py
+++ b/meraki_api/devices.py
@@ -2,7 +2,6 @@
 Meraki Devices API Resource
 """
 
-import urllib
 from .meraki_api_resource import MerakiAPIResource
 from .switch_ports import SwitchPorts
 from .utils import clean
@@ -36,7 +35,7 @@ class Devices(MerakiAPIResource):
         if query is None:
             raise ValueError("You must set the timespan query value.")
         query = clean(query, self.clients_parameters)
-        return self.get("/clients?" + urllib.parse.urlencode(query))
+        return self.get("/clients", query)
 
     def uplink(self):
         """ Return uplink status. """

--- a/meraki_api/lazy_requests.py
+++ b/meraki_api/lazy_requests.py
@@ -29,9 +29,11 @@ class LazyRequests():
         """
         def func():
             """ Function wrapper to lazily invoke requests.get. """
-            data = self.data if method == 'post' or 'put' else None
-            request_method = getattr(requests, method, None)
-            return request_method(self.url, headers=self.headers, data=data)
+            if method == 'get':
+                return requests.get(self.url, headers=self.headers, params=self.data)
+            else:
+                request_method = getattr(requests, method, None)
+                return request_method(self.url, headers=self.headers, data=self.data)
         self.cached = func
         return self
 

--- a/meraki_api/meraki_api_resource.py
+++ b/meraki_api/meraki_api_resource.py
@@ -98,7 +98,7 @@ class MerakiAPIResource:
         """ Dynamically create and call LazyRequest methods. """
         url = self.__build_url() + (str(suffix) if suffix is not None else "")
         headers = self.__headers()
-        if data is not None:
+        if data is not None and method != "get":
             data = json.dumps(data)
         func = getattr(LazyRequests(url, headers, data), method, None)
         if func is None:
@@ -106,11 +106,11 @@ class MerakiAPIResource:
         self.cached = func()
         return self if self.is_lazy is True else self.cached.call()
 
-    def get(self, suffix=None):
+    def get(self, suffix=None, data=None):
         """
         Returns a class that can call a ger request to a built URL lazily.
         """
-        return self.request("get", suffix)
+        return self.request("get", suffix, data=data)
 
     def post(self, suffix=None, data=None):
         """

--- a/meraki_api/networks.py
+++ b/meraki_api/networks.py
@@ -2,7 +2,6 @@
 Meraki Networks API Resource
 """
 
-import urllib
 from .meraki_api_resource import MerakiAPIResource
 from .devices import Devices
 from .ssids import SSIDs
@@ -73,7 +72,7 @@ class Networks(MerakiAPIResource):
         self.check_for_resource_id()
         self.check_timespan(query)
         query = clean(query, self.traffic_parameters)
-        return self.get("/traffic?" + urllib.parse.urlencode(query))
+        return self.get("/traffic", query)
 
     def bind(self, data):
         """ Binds template to network. """
@@ -96,7 +95,7 @@ class Networks(MerakiAPIResource):
         self.check_timespan(query)
         self.check_for_resource_id()
         query = clean(query, self.air_marshal_parameters)
-        return self.get("/airMarshal?" + urllib.parse.urlencode(query))
+        return self.get("/airMarshal", query)
 
     def phone_contacts(self, phone_contact_id=None):
         """ List the phone contacts in a network. """

--- a/meraki_api/sm.py
+++ b/meraki_api/sm.py
@@ -2,7 +2,6 @@
 Meraki SM API Resource
 """
 
-import urllib
 from .meraki_api_resource import MerakiAPIResource
 from .utils import clean
 
@@ -74,10 +73,7 @@ class SM(MerakiAPIResource):
         """ Returns the Networks SM Devices API Resource. """
         if query is not None:
             query = clean(query, self.devices_parameters)
-            query = "?" + urllib.parse.urlencode(query)
-        else:
-            query = ""
-        return self.get("/devices" + query)
+        return self.get("/devices", query)
 
     def modify_devices_tags(self, data):
         """ Add, delete, or update the tags of a set of devices. """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Meraki API Setup module.
 """
@@ -12,6 +13,13 @@ HERE = path.abspath(path.dirname(__file__))
 # Get the long description from the README file
 with codecs_open(path.join(HERE, 'README.rst'), encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
+
+# unittests
+import unittest
+def meraki_api_test_suite():
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover('tests', pattern='test_*.py')
+    return test_suite
 
 setup(
     name='meraki_api',
@@ -37,6 +45,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
@@ -52,6 +62,7 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=['requests'],
+    test_suite='setup.meraki_api_test_suite',
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:

--- a/tests/test_lazy_requests.py
+++ b/tests/test_lazy_requests.py
@@ -8,7 +8,12 @@ ADMIN_ID = "ADMIN_ID"
 
 import sys
 import unittest
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    # backup for python2
+    import mock
+
 # The context.py file on this folder sets up the context for the test case.
 from context import LazyRequests, build_mocked_requests_decorator
 
@@ -49,14 +54,15 @@ class TestMerakiApi(unittest.TestCase):
         # Run for each method
         map(test_check, self.methods)
 
-    def check_test_call(self, result, mocked):
+    def check_test_call(self, result, mocked, expected_args={}):
         """ Helper function used to test call() method. """
         self.assertEqual(result, RESPONSE)
-        expected_args = {
-            "url": URL,
-            "headers": HEADERS,
-            "data": DATA
-        }
+        if not expected_args:
+            expected_args = {
+                "url": URL,
+                "headers": HEADERS,
+                "data": DATA
+            }
         actual_args = mocked.call_args_list[0][1]
         actual_args["url"] = URL
         self.assertEqual(expected_args, actual_args)
@@ -70,7 +76,12 @@ class TestMerakiApi(unittest.TestCase):
         Should call the appropiate requests function of raise an Exception.
         """
         result = self.lazy_request.get().call().json()
-        self.check_test_call(result, mocked)
+        expected_args = {
+            "url": URL,
+            "headers": HEADERS,
+            "params": DATA
+        }
+        self.check_test_call(result, mocked, expected_args)
 
     @mock.patch(
         "requests.post"

--- a/tests/test_organizations_networks.py
+++ b/tests/test_organizations_networks.py
@@ -93,23 +93,27 @@ class TestMerakiApi(unittest.TestCase):
 
     def test_organization_networks_traffic(self):
         """ The organizations.networks.traffic endpoint should be correct. """
+        req = MerakiAPI(KEY).organizations(ORGANIZATION_ID).networks(NETWORK_ID).lazy().traffic({
+                "timespan": 7200,
+                "deviceType": "wireless"
+            })
+
         self.assertEqual(
             "https://dashboard.meraki.com/api/v0/organizations/"
             + ORGANIZATION_ID
             + "/networks/"
             + NETWORK_ID
-            + "/traffic?timespan=7200&deviceType=wireless"
-            , MerakiAPI(KEY)
-            .organizations(ORGANIZATION_ID)
-            .networks(NETWORK_ID)
-            .lazy()
-            .traffic({
-                "timespan": 7200,
-                "deviceType": "wireless"
-            })
+            + "/traffic"
+            , req
             .cached
             .url
         )
+        self.assertEqual(
+            {'deviceType': 'wireless', 'timespan': 7200}
+            , req
+            .cached
+            .data
+)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Excellent work on the library! A few minor changes are required to make it fully backwards-compatible with Python 2.7 without impacting future development:

- Added the mock library and import exception handler since mock not built-in for py2 unittest
- Added a test section for running unittests via `setup.py`
- Use `requests.get(url, headers, params={})` instead of url-encoding parameters since `requests` takes care of this for us.
- For minimal changes to other library calls added specific handlers in `lazy_requests.py` for `requests.get()` so `self.data` is not JSON encoded and the correct `params` field is used.
- Modified `tests/test_organizations_networks.py` to handle change to get requests.
- Made sure all unittests pass for py2 and py3